### PR TITLE
[Feat] #2 - 오픈웨더맵 API 연동하고 테스트 배치

### DIFF
--- a/weather-moji/weather-moji/Features/Weather/Weather.swift
+++ b/weather-moji/weather-moji/Features/Weather/Weather.swift
@@ -1,0 +1,26 @@
+struct WeatherResponse: Codable {
+    let name: String
+    let main: Main
+    let weather: [Weather]
+    let wind: Wind
+}
+
+struct Main: Codable {
+    let temp: Double
+    let humidity: Int
+}
+
+struct Weather: Codable {
+    let description: String
+    let icon: String
+}
+
+struct Wind: Codable {
+    let speed: Double
+}
+
+// 섭씨(C) -> 화씨(F) 변환
+extension Double {
+    var cToF: Double { (self * 9/5) + 32 }
+}
+

--- a/weather-moji/weather-moji/Features/Weather/WeatherViewModel.swift
+++ b/weather-moji/weather-moji/Features/Weather/WeatherViewModel.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+class WeatherViewModel {
+    private let service = WeatherService()
+    
+    var cityName: String = ""
+    var temperatureC: String = ""
+    var temperatureF: String = ""
+    var windSpeed: String = ""
+    var humidity: String = ""
+    
+    var onUpdate: (() -> Void)?
+    
+    func loadWeather(for city: String) {
+        service.fetchWeather(for: city) { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let data):
+                    self?.cityName = data.name
+                    self?.temperatureC = String(format: "%.1f°C", data.main.temp)
+                    self?.temperatureF = String(format: "%.1f°F", data.main.temp.cToF)
+                    self?.windSpeed = String(format: "%.1f m/s", data.wind.speed)
+                    self?.humidity = "\(data.main.humidity)%"
+                    self?.onUpdate?()
+                case .failure(let error):
+                    print("날씨 데이터 불러오기 실패:", error.localizedDescription)
+                }
+            }
+        }
+    }
+}
+

--- a/weather-moji/weather-moji/Network/WeatherService.swift
+++ b/weather-moji/weather-moji/Network/WeatherService.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+class WeatherService {
+    private let apiKey = "2dafcfcea7942ab35fd40ac0d151fe89"
+
+    func fetchWeather(for city: String, completion: @escaping (Result<WeatherResponse, Error>) -> Void) {
+        
+        let urlString = "https://api.openweathermap.org/data/2.5/weather?q=\(city)&appid=\(apiKey)&lang=kr&units=metric"
+        guard let url = URL(string: urlString) else { return }
+
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+
+            guard let data = data else { return }
+
+            do {
+                let weather = try JSONDecoder().decode(WeatherResponse.self, from: data)
+                completion(.success(weather))
+            } catch {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
+}
+

--- a/weather-moji/weather-moji/ViewController.swift
+++ b/weather-moji/weather-moji/ViewController.swift
@@ -1,12 +1,60 @@
 import UIKit
+import SnapKit
 
 class ViewController: UIViewController {
-
+    
+    private let viewModel = WeatherViewModel()
+    
+    private let cityLabel = UILabel()
+    private let tempLabel = UILabel()
+    private let tempFLabel = UILabel()
+    private let windLabel = UILabel()
+    private let humidityLabel = UILabel()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        
+        setupUI()
+        bindViewModel()
+        
+        // 지역 바꿔가면서 해보기.. 근데 영어로만 가능함
+        viewModel.loadWeather(for: "Seoul")
+    }
+    
+    private func setupUI() {
+        // 스택뷰 만들기
+        let stack = UIStackView(arrangedSubviews: [
+            cityLabel,
+            tempLabel,
+            tempFLabel,
+            windLabel,
+            humidityLabel
+        ])
 
+        // 스택뷰 기본 설정
+        stack.axis = .vertical
+        stack.alignment = .center
+        stack.spacing = 10
+        
+        // 스택뷰 화면에 추가
+        view.addSubview(stack)
+        
+        // 화면 중앙 배치
+        stack.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
     }
 
-
+    private func bindViewModel() {
+        viewModel.onUpdate = { [weak self] in
+            guard let self = self else { return }
+            self.cityLabel.text = "지역이름: \(self.viewModel.cityName)"
+            self.tempLabel.text = "온도(섭씨): \(self.viewModel.temperatureC)"
+            self.tempFLabel.text = "온도(화씨): \(self.viewModel.temperatureF)"
+            self.windLabel.text = "풍속: \(self.viewModel.windSpeed)"
+            self.humidityLabel.text = "습도: \(self.viewModel.humidity)"
+        }
+    }
 }
 


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #2 

`Weather` 파일에 모델 정의하고, `WeatherService` 파일에 네트워크 로직을 두고,
MVVM 패턴 적용시켜서 뷰모델에는 비즈니스로직, 뷰컨트롤러에는 UI 코드만 남겼습니다.
UI 코드는 UIKit 사용해서 임시로 배치해놨고, 추후에 정은님 UI 틀(Rxswift)로 바꿀 예정입니다.

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-04 at 11 39 35" src="https://github.com/user-attachments/assets/0e30e427-e4da-4b80-9325-306513929fe0" />
<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-04 at 11 39 54" src="https://github.com/user-attachments/assets/af9b609c-16cd-432c-b11c-f50b7ef900f0" />

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

```swift
viewModel.loadWeather(for: "Seoul")
```

이 부분 문자열 바꿔가면서 지역 날씨 테스트 가능합니다. 
영문만 가능하고, Seoul, Incheon, Busan, Jeonju 같이 도시단위로 표기해야됩니다!

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
