### PR TITLE
[Feat] #43 - 로고 탭 -> ForecastVC로 이동

### DIFF
--- a/weather-moji/weather-moji/Features/Search/View/ForecastViewController.swift
+++ b/weather-moji/weather-moji/Features/Search/View/ForecastViewController.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+class ForecastViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+    }
+}

--- a/weather-moji/weather-moji/Features/Search/View/SearchViewController.swift
+++ b/weather-moji/weather-moji/Features/Search/View/SearchViewController.swift
@@ -175,17 +175,33 @@ final class SearchViewController: UIViewController {
     
     // navigationTitle 이미지 설정
     private func setupNavigationTitle() {
-        let logoImageView = UIImageView(image: UIImage(named: "titleLogo"))
+        guard let logoImage = UIImage(named: "titleLogo") else { return }
+        
+        let logoImageView = UIImageView(image: logoImage)
         logoImageView.contentMode = .scaleAspectFit
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapTitleLogo))
         
         let container = UIView()
         container.addSubview(logoImageView)
+        container.isUserInteractionEnabled = true
+        container.addGestureRecognizer(tapGesture)
         
         logoImageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
-            $0.height.equalTo(40)
+        }
+        
+        container.snp.makeConstraints {
+            $0.width.equalTo(logoImage.size.width / 2.5)
+            $0.height.equalTo(logoImage.size.height / 2.5)
         }
         navigationItem.titleView = container
+    
+    }
+    
+    @objc private func tapTitleLogo() {
+        let forecastVC = ForecastViewController()
+        navigationController?.pushViewController(forecastVC, animated: true)
     }
     
     // 돋보기 버튼 설정


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #43 

![Simulator Screen Recording - iPhone 16 Pro - 2025-11-06 at 15 56 00](https://github.com/user-attachments/assets/0c086e7a-e420-4df7-b083-968208d07415)

- 로고 탭 -> ForecastVC로 화면 이동

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

화면으로 이동하는 기능 외에 타이틀 로고 이미지의 공백이 많아 공백 크기를 로고 이미지에 맞게 줄였습니다.
(공백을 터치했을 때 페이지가 넘어가는 상황을 방지하기 위해)

| 수정 전 공백 | 수정 후 공백
| :---: | :---: |
| <img width="1206" height="494" alt="image" src="https://github.com/user-attachments/assets/fdcd9381-83c5-4370-b0bd-e5f27d52e4bf" /> |<img width="1206" height="494" alt="image" src="https://github.com/user-attachments/assets/da5647d1-8ccf-474f-aed4-9b26e9a6bd13" /> |


# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네 
