### PR TITLE
[Feat] #44 - 5일예보 API 연동하고 테스트 배치

### DIFF
--- a/weather-moji/weather-moji/Features/Forecast/Model/ForecastResponse.swift
+++ b/weather-moji/weather-moji/Features/Forecast/Model/ForecastResponse.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+// 5일 예보 API 모델
+struct ForecastResponse: Codable {
+    let list: [Forecast]
+}
+
+// 각 예보 데이터 하나(3시간 단위)
+struct Forecast: Codable {
+    let dt: Int
+    let main: ForecastMain
+    let weather: [ForecastWeather]
+    let dt_txt: String
+}
+
+// 온도 정보
+struct ForecastMain: Codable {
+    let temp: Double
+    let temp_min: Double
+    let temp_max: Double
+    let humidity: Int?
+}
+
+// 날씨 상태 정보
+struct ForecastWeather: Codable {
+    let main: String
+    let description: String
+    let icon: String
+}
+

--- a/weather-moji/weather-moji/Features/Forecast/View/ForecastViewController.swift
+++ b/weather-moji/weather-moji/Features/Forecast/View/ForecastViewController.swift
@@ -1,0 +1,44 @@
+import UIKit
+import SnapKit
+
+final class ForecastViewController: UIViewController {
+    
+    private let viewModel = ForecastViewModel()
+    private let stackView = UIStackView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+        
+        setupUI()
+        bindViewModel()
+        viewModel.loadForecast()
+    }
+    
+    private func setupUI() {
+        stackView.axis = .vertical
+        stackView.spacing = 10
+        stackView.alignment = .center
+        view.addSubview(stackView)
+        
+        stackView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+    
+    private func bindViewModel() {
+        viewModel.onUpdate = { [weak self] in
+            guard let self = self else { return }
+            self.stackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
+            
+            for forecast in self.viewModel.forecasts {
+                let label = UILabel()
+                label.text = "\(forecast.dt_txt) , \(forecast.main.temp)°C"
+                label.textAlignment = .center
+                self.stackView.addArrangedSubview(label)
+            }
+        }
+    }
+}
+

--- a/weather-moji/weather-moji/Features/Forecast/ViewModel/ForecastViewModel.swift
+++ b/weather-moji/weather-moji/Features/Forecast/ViewModel/ForecastViewModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+final class ForecastViewModel {
+    private let service = WeatherService()
+    private(set) var forecasts: [Forecast] = []
+    
+    var onUpdate: (() -> Void)?
+    
+    func loadForecast() {
+        service.fetchForecast { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let response):
+                    // 12:00 시각만 필터링해서 5일치 데이터 저장
+                    self?.forecasts = response.list.filter { $0.dt_txt.contains("12:00:00") }
+                    self?.onUpdate?()
+                    
+                case .failure(let error):
+                    print("예보 불러오기 실패")
+                }
+            }
+        }
+    }
+}
+

--- a/weather-moji/weather-moji/Features/Search/View/SearchViewController.swift
+++ b/weather-moji/weather-moji/Features/Search/View/SearchViewController.swift
@@ -175,17 +175,33 @@ final class SearchViewController: UIViewController {
     
     // navigationTitle 이미지 설정
     private func setupNavigationTitle() {
-        let logoImageView = UIImageView(image: UIImage(named: "titleLogo"))
+        guard let logoImage = UIImage(named: "titleLogo") else { return }
+        
+        let logoImageView = UIImageView(image: logoImage)
         logoImageView.contentMode = .scaleAspectFit
+        
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(tapTitleLogo))
         
         let container = UIView()
         container.addSubview(logoImageView)
+        container.isUserInteractionEnabled = true
+        container.addGestureRecognizer(tapGesture)
         
         logoImageView.snp.makeConstraints {
             $0.edges.equalToSuperview()
-            $0.height.equalTo(40)
+        }
+        
+        container.snp.makeConstraints {
+            $0.width.equalTo(logoImage.size.width / 2.5)
+            $0.height.equalTo(logoImage.size.height / 2.5)
         }
         navigationItem.titleView = container
+    
+    }
+    
+    @objc private func tapTitleLogo() {
+        let forecastVC = ForecastViewController()
+        navigationController?.pushViewController(forecastVC, animated: true)
     }
     
     // 돋보기 버튼 설정

--- a/weather-moji/weather-moji/Network/WeatherService.swift
+++ b/weather-moji/weather-moji/Network/WeatherService.swift
@@ -24,5 +24,30 @@ class WeatherService {
             }
         }.resume()
     }
+    
+    func fetchForecast(completion: @escaping (Result<ForecastResponse, Error>) -> Void) {
+        // 서울 고정 (위도/경도)
+        let urlString = "https://api.openweathermap.org/data/2.5/forecast?lat=37.5665&lon=126.9780&appid=\(apiKey)&units=metric&lang=kr"
+        guard let url = URL(string: urlString) else {
+            print("잘못된 URL이다.")
+            return
+        }
+        
+        URLSession.shared.dataTask(with: url) { data, _, error in
+            if let error = error {
+                completion(.failure(error))
+                return
+            }
+            
+            guard let data = data else { return }
+            
+            do {
+                let decoded = try JSONDecoder().decode(ForecastResponse.self, from: data)
+                completion(.success(decoded))
+            } catch {
+                completion(.failure(error))
+            }
+        }.resume()
+    }
 }
 


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #44 

**자세한 과정은 개발로그에서 확인가능함**

- **5 day / 3 hour API**가 5일치 예보를 3시간 간격으로 줘서 40개 데이터가 하나의 리스트에 담겨있는 형태를 주는데, 그 한 덩이에서 날짜/온도/상태 정보만 빼서 구조체에 정의했습니다.

- WeatherService에 원래 있던 fetchWeather 밑에다가 fetchForecast 추가해주고, 예보 뷰모델에 loadForecast도 추가했습니다.

- 작업하던 도중에 정은님 PR이 올라와서 원격에 있던 서치 뷰컨트롤러를 그대로 떠와서 테스트 배치까지 완료했습니다!

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-06 at 16 24 29" src="https://github.com/user-attachments/assets/b563543b-2bdd-493e-826d-571648e30517" />

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
