### PR TITLE
[Design] #46 - ForecastVC의 navigationBar 커스텀

### DIFF
--- a/weather-moji/weather-moji/Features/Search/View/ForecastViewController.swift
+++ b/weather-moji/weather-moji/Features/Search/View/ForecastViewController.swift
@@ -4,6 +4,18 @@ class ForecastViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .white
+        navigationBarCustom()
+    }
+    
+    private func navigationBarCustom() {
+        navigationController?.navigationBar.tintColor = .white
+        
+        // 로고 이미지 추가
+        let logoImageView = UIImageView(image: UIImage(named: "titleLogo"))
+        logoImageView.contentMode = .scaleAspectFit
+        logoImageView.snp.makeConstraints {
+            $0.height.equalTo(45)
+        }
+        navigationItem.titleView = logoImageView
     }
 }

--- a/weather-moji/weather-moji/Features/Search/View/SearchViewController.swift
+++ b/weather-moji/weather-moji/Features/Search/View/SearchViewController.swift
@@ -201,6 +201,7 @@ final class SearchViewController: UIViewController {
     
     @objc private func tapTitleLogo() {
         let forecastVC = ForecastViewController()
+        navigationItem.backButtonTitle = ""
         navigationController?.pushViewController(forecastVC, animated: true)
     }
     


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #46 

- ForecastVC의 네비게이션 바를 디자인에 맞게 커스텀했습니다.

- 흰색으로 커스텀해야해서 `view.backgroundColor = .black`으로 작업하고 있었는데 서연님 PR을 보고 충돌이 일어날까봐 해당 부분은 삭제했습니다! 

- 결과물을 사진으로 보여드리기 위해 검정 배경이었을 때 사진을 첨부합니다.

<img width="250" height="500" alt="image" src="https://github.com/user-attachments/assets/5ce2cba7-a858-4b38-ac5e-3612b570df21" />


# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
