### PR TITLE
[Feat] #54 - 일기예보 날씨 아이콘 표시하기

### DIFF
--- a/weather-moji/weather-moji/Features/Forecast/View/ForecastCell.swift
+++ b/weather-moji/weather-moji/Features/Forecast/View/ForecastCell.swift
@@ -1,10 +1,3 @@
-//
-//  ForecastCell.swift
-//  weather-moji
-//
-//  Created by 김리하 on 11/7/25.
-//
-
 import UIKit
 import SnapKit
 
@@ -21,7 +14,7 @@ final class ForecastCell: UITableViewCell {
     }
     
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        fatalError("에러메세지")
     }
     
     private func setupUI() {
@@ -64,13 +57,13 @@ final class ForecastCell: UITableViewCell {
         }
     }
     
-    func configure(with forecast: Forecast, index: Int) {
+    func configure(with forecast: Forecast, index: Int, iconName: String) {
         let days = ["오늘", "내일", "모레", "3일 후", "4일 후"]
         dayLabel.text = days[index]
-        
         tempLabel.text = "\(Int(forecast.main.temp))°C"
-        weatherIcon.image = UIImage(systemName: "sun.max.fill")?.withRenderingMode(.alwaysOriginal)
+        weatherIcon.image = UIImage(named: iconName)
     }
+
 }
 
 

--- a/weather-moji/weather-moji/Features/Forecast/View/ForecastViewController.swift
+++ b/weather-moji/weather-moji/Features/Forecast/View/ForecastViewController.swift
@@ -84,7 +84,10 @@ extension ForecastViewController: UITableViewDataSource {
                 }
 
         let forecast = viewModel.forecasts[indexPath.row]
-        cell.configure(with: forecast, index: indexPath.row)
+        let mainWeather = forecast.weather.first?.main ?? ""
+        let icon = viewModel.iconName(for: mainWeather)
+        cell.configure(with: forecast, index: indexPath.row, iconName: icon)
+
         
         return cell
     }

--- a/weather-moji/weather-moji/Features/Forecast/ViewModel/ForecastViewModel.swift
+++ b/weather-moji/weather-moji/Features/Forecast/ViewModel/ForecastViewModel.swift
@@ -23,3 +23,17 @@ final class ForecastViewModel {
     }
 }
 
+// 아이콘 매핑하기
+extension ForecastViewModel {
+    func iconName(for main: String) -> String {
+        switch main {
+        case "Clear": return "sun"
+        case "Clouds": return "cloud"
+        case "Rain": return "rain"
+        case "Snow": return "snow"
+        case "Thunderstorm": return "storm"
+        default: return "default"
+        }
+    }
+}
+


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #54 

`ForecastCell`의 configure 함수에서 기본 UIImage로 표시되던 날씨 아이콘을 실제 날씨에 맞게 매핑시켰습니다.

날씨 아이콘 매핑은 `ForecastaViewModel` 안에서 익스텐션으로 빼서 작성했고, 
`WeatherViewModel`에서 사용했던 iconName함수와 똑같은 스위치문을 사용했습니다.

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-11-07 at 16 43 44" src="https://github.com/user-attachments/assets/c20740db-f426-4dea-b636-dc12088df441" />

# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
