### PR TITLE
[Design] #57 - 일기예보 상단 텍스트라벨 추가

### DIFF
--- a/weather-moji/weather-moji/Features/Forecast/View/ForecastViewController.swift
+++ b/weather-moji/weather-moji/Features/Forecast/View/ForecastViewController.swift
@@ -7,6 +7,16 @@ final class ForecastViewController: UIViewController, UITableViewDelegate {
     private let stackView = UIStackView()
     private let tableView = UITableView()
     
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "서울 날씨 모지?"
+        label.textColor = .white
+        label.font = .systemFont(ofSize: 18)
+        label.textAlignment = .center
+        return label
+    }()
+
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .gray
@@ -16,6 +26,8 @@ final class ForecastViewController: UIViewController, UITableViewDelegate {
         setupTableView()
         bindViewModel()
         viewModel.loadForecast()
+        showTitleLabelAnimation()
+
     }
     
     private func setupTableView() {
@@ -38,6 +50,12 @@ final class ForecastViewController: UIViewController, UITableViewDelegate {
     }
     
     private func setupUI() {
+        
+        view.addSubview(titleLabel)
+        titleLabel.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(40)
+            $0.centerX.equalToSuperview()
+        }
         
         stackView.axis = .vertical
         stackView.spacing = 10
@@ -68,7 +86,16 @@ final class ForecastViewController: UIViewController, UITableViewDelegate {
         }
         navigationItem.titleView = logoImageView
     }
+    
+    private func showTitleLabelAnimation() {
+        titleLabel.alpha = 0
+        UIView.animate(withDuration: 1.5) {
+            self.titleLabel.alpha = 1
+        }
+    }
+
 }
+
 extension ForecastViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return viewModel.forecasts.count


### PR DESCRIPTION
# 작업 내용

> 해결한 이슈 넘버와 간단한 설명을 적어주세요.
> 
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- Closes #57 

- ForecastVC 상단에 UILabel 추가
- 레이아웃, 폰트속성은 메인화면의 `지금 날씨 모지?`와 맞춤
- 페이드인 애니메이션 추가

https://github.com/user-attachments/assets/79253704-ec22-4872-9b8a-2cdc206ca5d8


# 질문 및 특이사항

> 해결하지 못한 부분이나 팀원들에게 알려줄 사항을 적어주세요!

# 체크리스트 

빌드가 되는 코드인가요? 네
 
Warning이 없는 코드인가요? 네
 
Merge할 브랜치가 올바른가요? 네
 
코딩 컨벤션이 올바른가요? 네
